### PR TITLE
Fix Catalan typos and inconsistent emails

### DIFF
--- a/condicions-rifa.html
+++ b/condicions-rifa.html
@@ -134,7 +134,7 @@
               <i class="bi bi-envelope"></i>
               <h3>Email</h3>
               <p>
-                <a href="mailto:santpoljocs+frikndau2026@gmail.com">santpoljocs@gmail.com</a>
+                <a href="mailto:info+frikndau2026@santpoljocs.cat">info@santpoljocs.cat</a>
               </p>
             </div>
           </div>
@@ -187,7 +187,7 @@
             <p>
               Sant Pol Jocs<br />
               Sant Pol de Mar<br />
-              <strong>Email:</strong> santpoljocs@gmail.com<br />
+              <strong>Email:</strong> info@santpoljocs.cat<br />
             </p>
 
             <div class="social-links">

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
           <div class="col-lg-6">
             <h2>QUÈ?</h2>
             <p>
-              <strong>🎲 L'associació Sant Pol Jocs us convida a la 2a
+              <strong>🎲 L'associació Sant Pol Jocs us convida a la 3a
                 edició de FRIK'N'DAU</strong>, el festival dedicat als
               jocs de taula!
             </p>
@@ -244,7 +244,7 @@
                 Partides massives
               </h3>
               <p>
-                Partides de <em>Els Homes Llop de Castronegro</em>. Descobrireu quins vilatans son llops abans que us
+                Partides de <em>Els Homes Llop de Castronegro</em>. Descobrireu quins vilatans són llops abans que us
                 matin?
               </p>
             </div>
@@ -570,7 +570,7 @@
         <div class="section-header">
           <h2>Edicions anteriors</h2>
           <div>
-            <p><a href="../frikndau-2025/">L'edició 2025</a> del FRIK'N'DAU va ser un exit!</p>
+            <p><a href="../frikndau-2025/">L'edició 2025</a> del FRIK'N'DAU va ser un èxit!</p>
             <br />
           </div>
           <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-5 g-5 text-body-secondary">

--- a/programa.html
+++ b/programa.html
@@ -226,7 +226,7 @@
                     target="_blank">aquí</a> si us interessa</span>
               </td>
 
-              <td rowspan="8" class="prototips">Prototips<span>Testejeu jocs no publicats. Descobriu el process de
+              <td rowspan="8" class="prototips">Prototips<span>Testejeu jocs no publicats. Descobriu el procés de
                   concepció i
                   publicació</span>
                 <ul>
@@ -353,7 +353,7 @@
                     target="_blank">aquí</a> si us interessa</span>
               </td>
 
-              <td rowspan="6" class="prototips">Prototips<span>Testejeu jocs no publicats. Descobriu el process de
+              <td rowspan="6" class="prototips">Prototips<span>Testejeu jocs no publicats. Descobriu el procés de
                   concepció i
                   publicació</span>
                 <ul>
@@ -579,7 +579,7 @@
             <p>
               Sant Pol Jocs<br />
               Sant Pol de Mar<br />
-              <strong>Email:</strong> santpoljocs@gmail.com<br />
+              <strong>Email:</strong> info@santpoljocs.cat<br />
             </p>
 
             <div class="social-links">


### PR DESCRIPTION
## Summary
- Fix Catalan spelling errors: `son` → `són`, `exit` → `èxit`, `process` → `procés`
- Fix edition number: `2a edició` → `3a edició` (to match "III Festival" in the title)
- Align contact email to `info@santpoljocs.cat` across `condicions-rifa.html` and `programa.html`

## Test plan
- [ ] Verify the text reads correctly on index.html, condicions-rifa.html, and programa.html
- [ ] Confirm email links work in contact sections and footers

🤖 Generated with [Claude Code](https://claude.com/claude-code)